### PR TITLE
Use Info_Line_number if Mineral_meter not present

### DIFF
--- a/drawing.py
+++ b/drawing.py
@@ -8,7 +8,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvas
 from matplotlib.figure import Figure
 
 
-def drawMeter(depthValues, width, height):
+def drawMeter(depthValues, width, height, meterLoaded):
         """
          draws pixmaps for down-hole meter. Maximum pixmap size is 32767 px so multiple pixmaps
          may be needed depending on depth of drill hole and image sizes
@@ -46,7 +46,7 @@ def drawMeter(depthValues, width, height):
         qp.setPen(QColor(222,222,222))
 
         # # draw meter pixmaps
-        for i in range(len(depthValues)):
+        for i in range(len(depthValues+1)):
             if i*tickSpace > (pxNum+1)*32767:
                 pxNum = pxNum + 1
                 if pxNum == (numPixmaps - 1):
@@ -62,11 +62,16 @@ def drawMeter(depthValues, width, height):
 
             if i == 0 and pxNum == 0:                                   # starting major tick and text
                 qp.drawRect(int(0.25*width), 20, int(0.75*width), 1)
-                qp.drawText(QPoint(0, 17), "{:.1f}".format(depthValues[i]) + ' m')
-             #elif i%numCoresPerBox == 0:                                            # other major ticks and text
+                if meterLoaded:
+                    qp.drawText(QPoint(0, 17), "{:.1f}".format(depthValues[i]) + ' m')
+                else:
+                    qp.drawText(QPoint(0, 17), "{:.0f}".format(depthValues[i]))
             else:
                 qp.drawRect(int(0.25*width), i*tickSpace+20-pxNum*32767, int(0.75*width), 1)
-                qp.drawText(QPoint(0, i*tickSpace-pxNum*32767+17), "{:.1f}".format(depthValues[i]) + ' m')
+                if meterLoaded:
+                    qp.drawText(QPoint(0, i*tickSpace-pxNum*32767+17), "{:.1f}".format(depthValues[i]) + ' m')
+                else:
+                    qp.drawText(QPoint(0, i*tickSpace-pxNum*32767+17), "{:.0f}".format(depthValues[i]))
 
         return pixmap
 

--- a/import_functions.py
+++ b/import_functions.py
@@ -38,6 +38,12 @@ def loadCsvData(mainDir, projName):
     minMeter = getMeter('Meter_mineral', specData, dataNames)
     gcMeter = getMeter('Meter_Geochemistry', specData, dataNames)
 
+    if len(minMeter)==0:
+        minMeter = getMeter('Info_Line_number', specData, dataNames)
+        meterLoaded = False
+    else:
+        meterLoaded = True
+
     minerals = natsorted(list(set(minerals)))
     minDataTypes = natsorted(list(set(minDataTypes)))
 
@@ -47,7 +53,7 @@ def loadCsvData(mainDir, projName):
     minData = nestedDict(specData, dataNames, 'mineral_', minerals, minDataTypes, units, minVals, maxVals)
     gcMinData = nestedDict(specData, dataNames, 'Geochemistry_', gcMinerals, gcMinDataTypes, units, minVals, maxVals)
 
-    return minData, gcMinData, minMeter, gcMeter
+    return minData, gcMinData, minMeter, gcMeter, meterLoaded
 
 def nestedDict(data, dataList, dataType, minerals, minDataTypes, units, minVals, maxVals):
     """

--- a/main.py
+++ b/main.py
@@ -562,7 +562,7 @@ class mainWindow(QMainWindow):
             QApplication.setOverrideCursor(Qt.WaitCursor)
 
             # load spectral metric data from _DATA.csv
-            self.minData, self.gcMinData, self.minMeter, self.gcMeter = loadCsvData(self.mainDir, self.projName)
+            self.minData, self.gcMinData, self.minMeter, self.gcMeter, self.meterLoaded = loadCsvData(self.mainDir, self.projName)
             self.minList = list(self.minData.keys()) + list(self.gcMinData.keys())                                              # can this global var be removed? 
 
             self.imDict = makeImDict(self.mainDir)
@@ -734,7 +734,7 @@ class mainWindow(QMainWindow):
         self.meterLabel.setStyleSheet('Background-Color: rgb(0,0,0)')
         
         # produce pixmap of meter
-        meter = drawMeter(self.meterVals, self.meterWidth, self.dataWidgetHeight)
+        meter = drawMeter(self.meterVals, self.meterWidth, self.dataWidgetHeight, self.meterLoaded)
 
         # set pixmap of meterLabel to meter pixmap
         self.meterLabel.setPixmap(meter[0])
@@ -780,6 +780,8 @@ class mainWindow(QMainWindow):
         meterVals = np.arange(self.minMeter[0],self.minMeter[-1],(self.minMeter[-1]-self.minMeter[0])/(np.floor(numPoints)-1))
         meterVals = np.append(meterVals,self.minMeter[-1])
 
+        if not self.meterLoaded:
+            meterVals = np.floor(meterVals).astype(int)
         return meterVals
 
     def initCoreWidget(self, imType, mineral):


### PR DESCRIPTION
Check for 'Mineral_meter' in _DATA csv when opening a new drill hole. If not present use 'Info_Line_number'  for meter values instead. 