### PR TITLE
Add depth marker

### DIFF
--- a/components/dashboard.py
+++ b/components/dashboard.py
@@ -103,6 +103,12 @@ class Dashboard(QScrollArea):
 
         self.data_container = DraggableContainer(data_content)
 
+        self.meter.depth_marker_toggled[bool, int].connect(
+            lambda show_marker, y: self.data_container.toggle_depth_marker(
+                show_marker, y
+            )
+        )
+
         self.header_container.widget_dragged.connect(
             self.data_container.insert_dragged_widget
         )
@@ -160,6 +166,11 @@ class Dashboard(QScrollArea):
 
     @Slot(dict)
     def add_data_panel(self, dataset_args: dict) -> None:
+        """Adds a new data panel to the dashboard.
+
+        Args:
+            dataset_args (dict): Parameters for the new dataset.
+        """
         dataset_config = dataset_args.get("config")
         if dataset_args["data_subtype"] == "Geochemistry":
             geochem_info = dataset_config.data(
@@ -280,7 +291,9 @@ class Dashboard(QScrollArea):
             )
         header.save_image.connect(
             lambda panel=panel, img_name=image_name, img_height=image_height:
-                self.save_panel_image(panel, img_name, img_height)
+                self.save_panel_image(
+                    panel, img_name, img_height
+                )
         )
 
         self.header_container.insert_panel(header)

--- a/components/data_header.py
+++ b/components/data_header.py
@@ -300,12 +300,13 @@ class DataHeader(QWidget):
 
         data_types = dataset.config["data"]
 
-        for type in data_types.items():
-            subtypes = type[1].keys()
-            for subtype in subtypes:
-                if type != self.data_type and subtype != self.data_subtype:
-                    mins = type[1][subtype].keys()
-                    if self.data_name in mins:
-                        opts.append([type[0], subtype])
+        if self.data_subtype not in ["Composite Images", "Composite Plot"]:
+            for type in data_types.items():
+                subtypes = type[1].keys()
+                for subtype in subtypes:
+                    if type != self.data_type and subtype != self.data_subtype:
+                        mins = type[1][subtype].keys()
+                        if self.data_name in mins:
+                            opts.append([type[0], subtype])
 
         return opts

--- a/components/dataset_selector.py
+++ b/components/dataset_selector.py
@@ -255,7 +255,7 @@ class DatasetSelector(Modal):
         """
         if self.comp_image_button.isChecked():
             self.comp_plot_button.setChecked(False)
-            self.meta_table.set_multi_data(True)
+            self.meta_table.set_comp_data(True)
 
             self.datatypes_list.clear_list()
             self.datatypes_list.set_items({"Spectral Images": ["Mineral"]})
@@ -264,7 +264,7 @@ class DatasetSelector(Modal):
 
         elif not self.comp_plot_button.isChecked():
             self._dataset_changed(self.selected_dataset)
-            self.meta_table.set_multi_data(False)
+            self.meta_table.set_comp_data(False)
             self.data_list.disable_multi()
             self.data_list.select(0)
 

--- a/components/draggable_container.py
+++ b/components/draggable_container.py
@@ -1,5 +1,6 @@
 import numpy as np
-from PySide6.QtWidgets import QHBoxLayout, QWidget
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QWidget
+from PySide6.QtGui import QResizeEvent
 from PySide6.QtCore import Qt, Signal, Slot
 
 from components.data_panel import DataPanel
@@ -26,6 +27,15 @@ class DraggableContainer(QWidget):
         super().__init__(parent=parent)
         self.setAcceptDrops(True)
 
+        self.show_depth_marker = False
+
+        self.depth_marker = QLabel(self)
+        self.depth_marker.setFixedSize(self.width(), 2)
+        self.depth_marker.setStyleSheet("background-color: rgba(255,0,0,125)")
+        self.depth_marker.setAttribute(Qt.WA_TransparentForMouseEvents)
+        self.depth_marker.raise_()
+        self.depth_marker.hide()
+
         self.layout = QHBoxLayout()
         self.layout.setSpacing(5)
         self.layout.setContentsMargins(0, 0, 0, 0)
@@ -33,6 +43,12 @@ class DraggableContainer(QWidget):
         self.header = header
 
         self.setLayout(self.layout)
+
+    def resizeEvent(self, event: QResizeEvent) -> None:
+        if self.show_depth_marker:
+            self.update_depth_marker(self.depth_marker.y())
+            self.depth_marker.setFixedWidth(self.width())
+        return super().resizeEvent(event)
 
     def dragEnterEvent(self, e) -> None:
         """Event to signal that the drag action has begun."""
@@ -108,3 +124,19 @@ class DraggableContainer(QWidget):
                     mineral_list.append(mineral)
 
         return mineral_list
+
+    @Slot(bool, int)
+    def toggle_depth_marker(self, show_depth_marker: bool, y: int) -> None:
+        """Toggles display of depth marker on dashboard."""
+        if show_depth_marker:
+            self.update_depth_marker(y)
+        else:
+            self.show_depth_marker = False
+            self.depth_marker.hide()
+
+    def update_depth_marker(self, y: int) -> None:
+        self.depth_marker.move(0, y)
+        self.depth_marker.setFixedWidth(self.width())
+        self.show_depth_marker = True
+        self.depth_marker.raise_()
+        self.depth_marker.show()


### PR DESCRIPTION
Adds a depth marker feature that allows users to draw a line across all panels in the dashboard when clicking on the meter. The mark is removed on next click,